### PR TITLE
ci: pass /api-key=FAKE_TRANSLATE_E2E to backend-pn playwright container

### DIFF
--- a/.github/workflows/dotnet-core-docker.yml
+++ b/.github/workflows/dotnet-core-docker.yml
@@ -822,7 +822,7 @@ jobs:
       run: sleep 30
     - name: Start the newly build Docker container
       id: docker-run
-      run: docker run --name my-container -p 4200:5000 --network data microtingas/work-items-planning-container:latest "/ConnectionString=host=mariadbtest;Database=420_Angular;user=root;password=secretpassword;port=3306;Convert Zero Datetime = true;SslMode=none;" > docker_run_log 2>&1 &
+      run: docker run --name my-container -p 4200:5000 --network data microtingas/work-items-planning-container:latest "/ConnectionString=host=mariadbtest;Database=420_Angular;user=root;password=secretpassword;port=3306;Convert Zero Datetime = true;SslMode=none;" "/api-key=FAKE_TRANSLATE_E2E" > docker_run_log 2>&1 &
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
The backend-configuration calendar **translation** e2e (`m/calendar-translation.spec.ts`) exercises the real translate code path, which the frontend short-circuits to deterministic `[<lang>] <text>` output **only** when the configured Google key equals the sentinel `FAKE_TRANSLATE_E2E`.

The plugin CI workflows (`eform-backendconfiguration-plugin`) already launch the backend with `"/api-key=FAKE_TRANSLATE_E2E"`, but this container workflow's backend `docker run` did not — so the translation shard (`m`) fails here with `toHaveValue("[de-DE] …")` → `Received: ""`. This adds the matching arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)