### PR TITLE
ci: set ALLOW_FAKE_TRANSLATE=true for backend-pn translation shard

### DIFF
--- a/.github/workflows/dotnet-core-docker.yml
+++ b/.github/workflows/dotnet-core-docker.yml
@@ -822,7 +822,7 @@ jobs:
       run: sleep 30
     - name: Start the newly build Docker container
       id: docker-run
-      run: docker run --name my-container -p 4200:5000 --network data microtingas/work-items-planning-container:latest "/ConnectionString=host=mariadbtest;Database=420_Angular;user=root;password=secretpassword;port=3306;Convert Zero Datetime = true;SslMode=none;" "/api-key=FAKE_TRANSLATE_E2E" > docker_run_log 2>&1 &
+      run: docker run --name my-container -p 4200:5000 --network data -e ALLOW_FAKE_TRANSLATE=true microtingas/work-items-planning-container:latest "/ConnectionString=host=mariadbtest;Database=420_Angular;user=root;password=secretpassword;port=3306;Convert Zero Datetime = true;SslMode=none;" "/api-key=FAKE_TRANSLATE_E2E" > docker_run_log 2>&1 &
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Adds `-e ALLOW_FAKE_TRANSLATE=true` to the backend-pn playwright `docker run` (line 825), ahead of gating the `FAKE_TRANSLATE_E2E` sentinel in `eform-angular-frontend` `TranslationService`. Currently a no-op (env ignored). Reaches the release lineage when master is merged in at the next `v*.*.*` tag.

See spec `2026-06-11-translation-real-apikey-prod-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)